### PR TITLE
Numerous PKGBUILD fixes and improvements

### DIFF
--- a/archpkg/PKGBUILD
+++ b/archpkg/PKGBUILD
@@ -1,26 +1,35 @@
 # Maintainer: Aidan Neal <decator(dot)c(at)proton(dot)me>
-pkgname="qinfo-git"
-_pkgname="qinfo"
-pkgver=r70.rb3f292d.
+pkgname=qinfo-git
+pkgver=r71.ce31f95
 pkgrel=1
-pkgdesc="A cross platform system info program. Fetches system info and displays it."
-arch=("x86_64")
+pkgdesc="A system info program. Fetches system info and displays it."
+arch=('x86_64')
 url="https://github.com/El-Wumbus/qinfo"
-license=("GPL3")
-provides=("qinfo")
-makedepends=("gcc" "make")
-depends=("coreutils")
-optdepends=("snapd: List number of snap packages"
-            "flatpak: List number of flatpak packages")
-source=($_pkgname::"git+https://github.com/El-Wumbus/qinfo.git")
-sha256sums=("SKIP")
+license=('GPL3')
+provides=("${pkgname%-git}")
+conflicts=("${pkgname%-git}")
+makedepends=('git')
+source=('git+https://github.com/El-Wumbus/qinfo.git')
+sha256sums=('SKIP')
 
 pkgver() {
-  cd "$_pkgname"
-  printf "r%s.$s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+  cd "$srcdir/${pkgname%-git}"
+  printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+
+prepare() {
+  cd "$srcdir/${pkgname%-git}"
+
+  # Don't override default CFLAGS
+  sed -i 's/CFLAGS=/CFLAGS+=/g' Makefile
+}
+
+build() {
+  cd "$srcdir/${pkgname%-git}"
+  make
 }
 
 package() {
-  cd "$_pkgname"
-  make DESTDIR="${pkgdir}" install
+  cd "$srcdir/${pkgname%-git}"
+  make DESTDIR="$pkgdir" install
 }


### PR DESCRIPTION
* Technically it depends on `glibc`, but it's not really necessary to define it as it's pulled in by core packages. Same with `coreutils`. You can add them if you wish.
* No need to add the optional dependencies. Either folks are using Snap and Flatpak or they aren't.
* Members of the `base-devel` group are assumed installed and do not need to be added to makedepends().
* Your Makefile explicitly defines `CFLAGS` which don't allow the default flags defined in `/etc/makepkg.conf` to be used.
* Please see [VCS package guidelines](https://wiki.archlinux.org/title/VCS_package_guidelines)